### PR TITLE
Implement transit stop timing widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+## iOS Widget
+
+This project ships with a native **Stop Timings** widget that lets you pin upcoming departures for any TPG stop directly to your iPhone Home Screen.
+
+### Selecting a stop
+1. Long-press the Home Screen and tap the `+` button to add a new widget.
+2. Search for **TPG Stop Timings** and add it to the desired location.
+3. After placing the widget, choose **Edit Widget**.
+4. Enter the *DIDOC* code of the stop you’d like to monitor (e.g. `TPGN`) and, optionally, a comma-separated list of line numbers to filter (e.g. `12, 18`).
+
+The widget will refresh itself every minute and colour-code the line badge with the official network colour where available.
+
+### Building on device / simulator
+Run one of the custom scripts:
+
+```bash
+# Development build on the connected iPhone simulator
+yarn run:iphone
+
+# Release build & deploy to a connected device
+yarn deploy:iphone
+```
+
+Both scripts automatically include the widget target thanks to `@bacons/apple-targets`.

--- a/app.config.js
+++ b/app.config.js
@@ -82,6 +82,13 @@ export default {
         }
       ],
       [
+        "@bacons/apple-targets",
+        {
+          appleTeamId: "XXXXXXXXXX",
+          targets: ["./targets/widget/expo-target.config.js"]
+        }
+      ],
+      [
         "expo-build-properties",
         {
           ios: {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-web": "^0.20.0",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "@bacons/apple-targets": "^0.0.4"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.23.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@bacons/apple-targets':
+        specifier: ^0.0.4
+        version: 0.0.4
       '@expo/vector-icons':
         specifier: ^14.0.4
         version: 14.1.0(expo-font@13.3.2(expo@53.0.20(@babel/core@7.28.0)(@expo/metro-runtime@5.0.4(react-native@0.79.5(@babel/core@7.28.0)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.5(@babel/core@7.28.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -630,6 +633,12 @@ packages:
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
+  '@bacons/apple-targets@0.0.4':
+    resolution: {integrity: sha512-K+txUguWUrMh3Op9nFplhYsem03evLuHgHNvjURZN05x+ZmnPLKfgiX8SykRObQ42qI3lt2y7BrIDmRfrBNEbg==}
+
+  '@bacons/xcode@1.0.0-alpha.25':
+    resolution: {integrity: sha512-HE/2UXkIFrKq/ZvxvB8b1OIk47Nf+jXDYJsAVfSoxCu3pNW/Zrws3ad/HbB/wWYb+bDvr4PD2wfGuNcTRbUQNQ==}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -733,6 +742,9 @@ packages:
 
   '@expo/package-manager@1.8.6':
     resolution: {integrity: sha512-gcdICLuL+nHKZagPIDC5tX8UoDDB8vNA5/+SaQEqz8D+T2C4KrEJc2Vi1gPAlDnKif834QS6YluHWyxjk0yZlQ==}
+
+  '@expo/plist@0.0.18':
+    resolution: {integrity: sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==}
 
   '@expo/plist@0.3.5':
     resolution: {integrity: sha512-9RYVU1iGyCJ7vWfg3e7c/NVyMFs8wbl+dMWZphtFtsqyN9zppGREU3ctlD3i8KUE0sCUTVnLjCWr+VeUIDep2g==}
@@ -1263,6 +1275,11 @@ packages:
     resolution: {integrity: sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg==}
     peerDependencies:
       '@urql/core': ^5.0.0
+
+  '@xmldom/xmldom@0.7.13':
+    resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
+    engines: {node: '>=10.0.0'}
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -3996,6 +4013,10 @@ packages:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     hasBin: true
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -4122,6 +4143,10 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlbuilder@14.0.0:
+    resolution: {integrity: sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==}
+    engines: {node: '>=8.0'}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -4784,6 +4809,22 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@bacons/apple-targets@0.0.4':
+    dependencies:
+      '@bacons/xcode': 1.0.0-alpha.25
+      fs-extra: 11.2.0
+      glob: 10.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@bacons/xcode@1.0.0-alpha.25':
+    dependencies:
+      '@expo/plist': 0.0.18
+      debug: 4.4.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
@@ -5091,6 +5132,12 @@ snapshots:
       npm-package-arg: 11.0.3
       ora: 3.4.0
       resolve-workspace-root: 2.0.0
+
+  '@expo/plist@0.0.18':
+    dependencies:
+      '@xmldom/xmldom': 0.7.13
+      base64-js: 1.5.1
+      xmlbuilder: 14.0.0
 
   '@expo/plist@0.3.5':
     dependencies:
@@ -5800,6 +5847,8 @@ snapshots:
     dependencies:
       '@urql/core': 5.2.0
       wonka: 6.3.5
+
+  '@xmldom/xmldom@0.7.13': {}
 
   '@xmldom/xmldom@0.8.10': {}
 
@@ -9052,6 +9101,8 @@ snapshots:
 
   uuid@7.0.3: {}
 
+  uuid@8.3.2: {}
+
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
@@ -9172,6 +9223,8 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlbuilder@14.0.0: {}
 
   xmlbuilder@15.1.1: {}
 

--- a/targets/widget/StopTimingsWidget.swift
+++ b/targets/widget/StopTimingsWidget.swift
@@ -1,0 +1,203 @@
+import WidgetKit
+import SwiftUI
+import AppIntents
+
+// MARK: - Intent Definition
+
+struct SelectStopIntent: AppIntent {
+    static var title: LocalizedStringResource = "Select Stop"
+    static var description = IntentDescription("Choose a TPG stop to display upcoming departures.")
+
+    @Parameter(title: "Stop DIDOC Code")
+    var stopId: String
+
+    @Parameter(title: "Line Numbers (comma-separated)")
+    var numbers: String?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Show departures for \(\.$stopId) filtered by \(\.$numbers)")
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        .result(dialog: "Stop updated")
+    }
+}
+
+// MARK: - Model
+
+struct DepartureInfo: Hashable, Codable {
+    let line: String
+    let destination: String
+    let minutes: Int
+    let colorHex: String?
+}
+
+struct StopTimingsEntry: TimelineEntry {
+    let date: Date
+    let stopName: String
+    let departures: [DepartureInfo]
+}
+
+// MARK: - Timeline Provider
+
+struct StopTimingsProvider: IntentTimelineProvider {
+    typealias Intent = SelectStopIntent
+    typealias Entry = StopTimingsEntry
+
+    func placeholder(in context: Context) -> StopTimingsEntry {
+        StopTimingsEntry(date: Date(), stopName: "Place des Nations", departures: sampleDepartures())
+    }
+
+    func getSnapshot(for configuration: SelectStopIntent, in context: Context, completion: @escaping (StopTimingsEntry) -> Void) {
+        let entry = StopTimingsEntry(date: Date(), stopName: "Snapshot", departures: sampleDepartures())
+        completion(entry)
+    }
+
+    func getTimeline(for configuration: SelectStopIntent, in context: Context, completion: @escaping (Timeline<StopTimingsEntry>) -> Void) {
+        Task {
+            let stopId = configuration.stopId.trimmingCharacters(in: .whitespacesAndNewlines)
+            let numbers = configuration.numbers?.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            let (stopName, deps) = await fetchDepartures(stopId: stopId, numberFilters: numbers ?? [])
+            let entry = StopTimingsEntry(date: Date(), stopName: stopName, departures: deps)
+            // Refresh after 1 minute
+            let nextUpdate = Calendar.current.date(byAdding: .minute, value: 1, to: Date()) ?? Date().addingTimeInterval(60)
+            let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+            completion(timeline)
+        }
+    }
+
+    // MARK: Network
+    private func fetchDepartures(stopId: String, numberFilters: [Substring]) async -> (String, [DepartureInfo]) {
+        guard !stopId.isEmpty else {
+            return ("No stop selected", sampleDepartures())
+        }
+
+        let urlString = "https://search.ch/timetable/api/stationboard.fr.json?stop=\(stopId)&limit=30&show_delays=1&transportation_types=tram,bus&mode=depart"
+        guard let url = URL(string: urlString) else {
+            return ("Invalid URL", sampleDepartures())
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let response = try JSONDecoder().decode(StationboardResponse.self, from: data)
+            let stopName = response.stop?.name ?? "Unknown"
+            let now = Date()
+            let isoFormatter = ISO8601DateFormatter()
+            isoFormatter.formatOptions.insert(.withFractionalSeconds)
+
+            let departures = (response.connections ?? []).compactMap { conn -> DepartureInfo? in
+                guard let line = conn.line, let destination = conn.terminal?.name, let timeStr = conn.time, let date = isoFormatter.date(from: timeStr) ?? ISO8601DateFormatter().date(from: timeStr) else {
+                    return nil
+                }
+                let minutes = Int(date.timeIntervalSince(now) / 60)
+                if minutes < 0 { return nil }
+                if !numberFilters.isEmpty && !numberFilters.contains(where: { line.contains($0) }) {
+                    return nil
+                }
+                return DepartureInfo(line: line, destination: destination, minutes: minutes, colorHex: conn.color?.split(separator: "~").first.map { "#\($0)" })
+            }.prefix(3).map { $0 }
+
+            return (stopName, Array(departures))
+        } catch {
+            return ("Error", sampleDepartures())
+        }
+    }
+
+    private func sampleDepartures() -> [DepartureInfo] {
+        [
+            DepartureInfo(line: "12", destination: "Carouge", minutes: 5, colorHex: "#FF6600"),
+            DepartureInfo(line: "18", destination: "Lancy", minutes: 8, colorHex: "#FF6600"),
+            DepartureInfo(line: "3", destination: "Gare Cornavin", minutes: 12, colorHex: "#FF6600")
+        ]
+    }
+}
+
+// MARK: - Widget View
+
+struct StopTimingsWidgetView: View {
+    var entry: StopTimingsProvider.Entry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(entry.stopName)
+                .font(.headline)
+            ForEach(entry.departures, id: \.self) { dep in
+                HStack {
+                    Text(dep.line)
+                        .font(.subheadline.bold())
+                        .foregroundColor(Color(hex: dep.colorHex ?? "#FF6600"))
+                        .frame(width: 30, alignment: .leading)
+                    Text(dep.destination)
+                        .font(.subheadline)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer()
+                    Text("\(dep.minutes)m")
+                        .font(.subheadline.monospacedDigit())
+                }
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+// MARK: - Widget Definition
+
+struct StopTimingsWidget: Widget {
+    let kind: String = "StopTimingsWidget"
+
+    var body: some WidgetConfiguration {
+        IntentConfiguration(kind: kind, intent: SelectStopIntent.self, provider: StopTimingsProvider()) { entry in
+            StopTimingsWidgetView(entry: entry)
+        }
+        .configurationDisplayName("TPG Stop Timings")
+        .description("Displays upcoming departures for a selected stop.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Helpers
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int = UInt64()
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 255, 165, 0)
+        }
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}
+
+// MARK: - Networking Models
+
+struct StationboardResponse: Decodable {
+    struct Connection: Decodable {
+        struct Terminal: Decodable { let name: String? }
+        let time: String?
+        let terminal: Terminal?
+        let type: String?
+        let line: String?
+        let color: String?
+        let delay: Int?
+    }
+    struct StopInfo: Decodable { let name: String? }
+    let stop: StopInfo?
+    let connections: [Connection]?
+}

--- a/targets/widget/expo-target.config.js
+++ b/targets/widget/expo-target.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@bacons/apple-targets').Config} */
+module.exports = {
+  type: "widget",
+  icon: "../../assets/images/ios-light.png",
+  colors: {
+    $accent: "#FF6600",
+    $widgetBackground: "#FFFFFF",
+  },
+  entitlements: {
+    "com.apple.security.application-groups": ["group.com.rohanodwyer.tpgtimes"],
+  },
+};

--- a/targets/widget/index.swift
+++ b/targets/widget/index.swift
@@ -1,0 +1,9 @@
+import WidgetKit
+import SwiftUI
+
+@main
+struct TPGTimesWidgets: WidgetBundle {
+    var body: some Widget {
+        StopTimingsWidget()
+    }
+}


### PR DESCRIPTION
Adds an iOS widget to display real-time public transport departures for user-selected stops.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba90f26a-1db3-4e0e-b2e5-4d0da1ca6248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba90f26a-1db3-4e0e-b2e5-4d0da1ca6248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

